### PR TITLE
feat: 사용자 추천 internal API 사용자 키워드, 사용자 키워드+서재 책

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Query, HTTPException
 from pydantic import BaseModel
 from app.recommend import model
+from app.recommend import user_recommender
 from app.db import fetch_books, fetch_book_reviews
 from app.recommend.bert_recommender import BertRecommender
 from app.recommend.tfidf_recommender import TfidfRecommender
@@ -180,3 +181,45 @@ def search_bert(request: TextSearchRequest):
         "results": items,
         "method": "bert_combined" if request.use_combined else "bert_keywords"
     }
+
+# 사용자 추천 API - 키워드만 사용
+@router.get("/recommend/users/keywords")
+def recommend_users_keywords(
+    member_id: int = Query(..., description="추천 대상 멤버 ID"),
+    top_k: int = Query(10, ge=1, le=50, description="추천할 사용자 수")
+):
+    """
+    사용자가 선택한 키워드만을 기반으로 유사한 사용자 추천
+    """
+    try:
+        recommendations = user_recommender.recommend_users_by_keywords(member_id, top_k)
+        return {
+            "memberId": member_id,
+            "recommendations": recommendations,
+            "method": "USER_KEYWORDS_ONLY"
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+# 사용자 추천 API - 키워드 + 서재 책
+@router.get("/recommend/users/combined")
+def recommend_users_combined(
+    member_id: int = Query(..., description="추천 대상 멤버 ID"),
+    top_k: int = Query(10, ge=1, le=50, description="추천할 사용자 수")
+):
+    """
+    사용자의 키워드 + 서재 책 정보를 기반으로 유사한 사용자 추천
+    """
+    try:
+        recommendations = user_recommender.recommend_users_by_keywords_and_books(member_id, top_k)
+        return {
+            "memberId": member_id,
+            "recommendations": recommendations,
+            "method": "USER_KEYWORDS_AND_BOOKS"
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Column, Integer, String, Text, TIMESTAMP, Enum
+from sqlalchemy import Column, Integer, String, Text, TIMESTAMP, Enum, ForeignKey, Table, BigInteger
+from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from app.db.database import Base
 import enum
@@ -6,6 +7,18 @@ import enum
 class SourceFieldEnum(enum.Enum):
     CRAWLING = "CRAWLING"
     MANUAL = "MANUAL"
+
+class KeywordTypeEnum(enum.Enum):
+    MOOD = "MOOD"
+    GENRE = "GENRE"
+    CONTENT = "CONTENT"
+
+member_keywords = Table(
+    'member_keywords',
+    Base.metadata,
+    Column('member_id', BigInteger, ForeignKey('members.member_id'), primary_key=True),
+    Column('keyword_id', BigInteger, ForeignKey('keywords.keyword_id'), primary_key=True)
+)
 
 class Book(Base):
     __tablename__ = "books"
@@ -23,3 +36,37 @@ class Book(Base):
     source_field = Column(Enum(SourceFieldEnum), default=SourceFieldEnum.CRAWLING)
     created_at = Column(TIMESTAMP, server_default=func.now())
     updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
+    
+    bookhouses = relationship("Bookhouse", back_populates="book")
+
+class Member(Base):
+    __tablename__ = "members"
+    __table_args__ = {"mysql_charset": "utf8mb4"}
+    
+    member_id = Column(BigInteger, primary_key=True, index=True)
+    
+    keywords = relationship("Keyword", secondary=member_keywords, back_populates="members")
+    bookhouses = relationship("Bookhouse", back_populates="member")
+
+class Keyword(Base):
+    __tablename__ = "keywords"
+    __table_args__ = {"mysql_charset": "utf8mb4"}
+    
+    keyword_id = Column(BigInteger, primary_key=True, index=True)
+    content = Column(String(100), nullable=False)
+    type = Column(Enum(KeywordTypeEnum))
+    
+    members = relationship("Member", secondary=member_keywords, back_populates="keywords")
+
+class Bookhouse(Base):
+    __tablename__ = "bookhouses"
+    __table_args__ = {"mysql_charset": "utf8mb4"}
+    
+    bookhouse_id = Column(BigInteger, primary_key=True, index=True)
+    member_id = Column(BigInteger, ForeignKey('members.member_id'))
+    book_id = Column(Integer, ForeignKey('books.book_id'))
+    created_at = Column(TIMESTAMP, server_default=func.now())
+    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
+    
+    member = relationship("Member", back_populates="bookhouses")
+    book = relationship("Book", back_populates="bookhouses")

--- a/app/recommend/user_recommender.py
+++ b/app/recommend/user_recommender.py
@@ -1,0 +1,237 @@
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+from app.db.database import SessionLocal
+from app.db import models
+import numpy as np
+from typing import List, Tuple, Dict
+
+def recommend_users_by_keywords(member_id: int, top_n: int = 10) -> List[Dict]:
+    """
+    사용자가 선택한 키워드만을 기반으로 유사한 사용자 추천
+    """
+    db = SessionLocal()
+    try:
+        # 1. 대상 사용자의 키워드 가져오기
+        target_member = db.query(models.Member).filter(
+            models.Member.member_id == member_id
+        ).first()
+        
+        if not target_member:
+            raise ValueError(f"Member {member_id} not found")
+        
+        target_keywords = [kw.content for kw in target_member.keywords]
+        if not target_keywords:
+            return []
+        
+        # 2. 다른 사용자들의 키워드 가져오기
+        other_members = db.query(models.Member).filter(
+            models.Member.member_id != member_id
+        ).all()
+        
+        if not other_members:
+            return []
+        
+        # 3. TF-IDF 벡터화
+        member_keyword_texts = []
+        valid_members = []
+        
+        for member in other_members:
+            member_keywords = [kw.content for kw in member.keywords]
+            if member_keywords:
+                member_keyword_texts.append(" ".join(member_keywords))
+                valid_members.append(member)
+        
+        if not valid_members:
+            return []
+        
+        # 대상 사용자 키워드 텍스트
+        target_text = " ".join(target_keywords)
+        
+        # TF-IDF 벡터화
+        vectorizer = TfidfVectorizer()
+        all_texts = member_keyword_texts + [target_text]
+        tfidf_matrix = vectorizer.fit_transform(all_texts)
+        
+        # 타겟 벡터와 다른 사용자들 벡터 분리
+        target_vector = tfidf_matrix[-1]
+        other_vectors = tfidf_matrix[:-1]
+        
+        # 4. 코사인 유사도 계산
+        similarities = cosine_similarity(target_vector, other_vectors).flatten()
+        
+        # 5. 상위 N명 선택
+        top_indices = similarities.argsort()[::-1][:top_n]
+        
+        # 6. 결과 구성
+        recommendations = []
+        for idx in top_indices:
+            if similarities[idx] > 0:  # 유사도가 0보다 큰 경우만
+                member = valid_members[idx]
+                member_keywords = [kw.content for kw in member.keywords]
+                
+                # 매칭된 키워드 찾기
+                matched_keywords = list(set(target_keywords) & set(member_keywords))
+                
+                recommendations.append({
+                    "memberId": int(member.member_id),
+                    "similarity": float(similarities[idx]),
+                    "matchedKeywords": matched_keywords,
+                    "matchType": "KEYWORD_ONLY"
+                })
+        
+        return recommendations
+        
+    finally:
+        db.close()
+
+
+def recommend_users_by_keywords_and_books(member_id: int, top_n: int = 10) -> List[Dict]:
+    """
+    사용자의 키워드 + 서재 책 정보를 기반으로 유사한 사용자 추천
+    """
+    db = SessionLocal()
+    try:
+        # 1. 대상 사용자의 키워드 및 서재 책 정보 가져오기
+        target_member = db.query(models.Member).filter(
+            models.Member.member_id == member_id
+        ).first()
+        
+        if not target_member:
+            raise ValueError(f"Member {member_id} not found")
+        
+        # 키워드
+        target_keywords = [kw.content for kw in target_member.keywords]
+        
+        # 서재 책 정보
+        target_bookhouses = db.query(models.Bookhouse).filter(
+            models.Bookhouse.member_id == member_id
+        ).all()
+        
+        target_books = []
+        for bookhouse in target_bookhouses:
+            book = db.query(models.Book).filter(
+                models.Book.book_id == bookhouse.book_id
+            ).first()
+            if book:
+                target_books.append(book)
+        
+        if not target_keywords and not target_books:
+            return []
+        
+        # 2. 다른 사용자들의 정보 가져오기
+        other_members = db.query(models.Member).filter(
+            models.Member.member_id != member_id
+        ).all()
+        
+        if not other_members:
+            return []
+        
+        # 3. 각 사용자의 특징 벡터 생성
+        member_feature_texts = []
+        valid_members = []
+        member_book_ids = {}
+        member_keyword_list = {}
+        
+        for member in other_members:
+            # 키워드
+            member_keywords = [kw.content for kw in member.keywords]
+            
+            # 서재 책 정보
+            member_bookhouses = db.query(models.Bookhouse).filter(
+                models.Bookhouse.member_id == member.member_id
+            ).all()
+            
+            member_books = []
+            book_ids = []
+            for bookhouse in member_bookhouses:
+                book = db.query(models.Book).filter(
+                    models.Book.book_id == bookhouse.book_id
+                ).first()
+                if book:
+                    member_books.append(book)
+                    book_ids.append(book.book_id)
+            
+            if member_keywords or member_books:
+                # 키워드 텍스트
+                keyword_text = " ".join(member_keywords) if member_keywords else ""
+                
+                # 책 관련 텍스트 (책 키워드 + 제목)
+                book_texts = []
+                for book in member_books:
+                    if book.keyword:
+                        book_texts.append(book.keyword)
+                    book_texts.append(book.book_name or "")
+                book_text = " ".join(book_texts)
+                
+                # 통합 텍스트
+                combined_text = f"{keyword_text} {book_text}".strip()
+                if combined_text:
+                    member_feature_texts.append(combined_text)
+                    valid_members.append(member)
+                    member_book_ids[member.member_id] = book_ids
+                    member_keyword_list[member.member_id] = member_keywords
+        
+        if not valid_members:
+            return []
+        
+        # 대상 사용자의 특징 텍스트
+        target_keyword_text = " ".join(target_keywords) if target_keywords else ""
+        target_book_texts = []
+        target_book_ids = []
+        for book in target_books:
+            if book.keyword:
+                target_book_texts.append(book.keyword)
+            target_book_texts.append(book.book_name or "")
+            target_book_ids.append(book.book_id)
+        target_book_text = " ".join(target_book_texts)
+        target_text = f"{target_keyword_text} {target_book_text}".strip()
+        
+        # 4. TF-IDF 벡터화
+        vectorizer = TfidfVectorizer()
+        all_texts = member_feature_texts + [target_text]
+        tfidf_matrix = vectorizer.fit_transform(all_texts)
+        
+        # 타겟 벡터와 다른 사용자들 벡터 분리
+        target_vector = tfidf_matrix[-1]
+        other_vectors = tfidf_matrix[:-1]
+        
+        # 5. 코사인 유사도 계산
+        similarities = cosine_similarity(target_vector, other_vectors).flatten()
+        
+        # 6. 상위 N명 선택
+        top_indices = similarities.argsort()[::-1][:top_n]
+        
+        # 7. 결과 구성
+        recommendations = []
+        for idx in top_indices:
+            if similarities[idx] > 0:  # 유사도가 0보다 큰 경우만
+                member = valid_members[idx]
+                
+                # 매칭된 키워드 찾기
+                matched_keywords = list(set(target_keywords) & set(member_keyword_list[member.member_id]))
+                
+                # 매칭된 책 찾기
+                matched_book_ids = list(set(target_book_ids) & set(member_book_ids[member.member_id]))
+                matched_books = []
+                for book_id in matched_book_ids:
+                    book = db.query(models.Book).filter(
+                        models.Book.book_id == book_id
+                    ).first()
+                    if book:
+                        matched_books.append({
+                            "bookId": book.book_id,
+                            "bookName": book.book_name
+                        })
+                
+                recommendations.append({
+                    "memberId": int(member.member_id),
+                    "similarity": float(similarities[idx]),
+                    "matchedKeywords": matched_keywords,
+                    "matchedBooks": matched_books,
+                    "matchType": "KEYWORD_AND_BOOK"
+                })
+        
+        return recommendations
+        
+    finally:
+        db.close()


### PR DESCRIPTION
## ✨ Issue Number
> close #이슈번호

## 📄 작업 내용 (주요 변경 사항)
TF-IDF 벡터화 및 코사인 유사도 활용한 추천 알고리즘을 사용한 취향 기반 추천 유저 조회 API에 사용되는 internal api 입니다.
키워드 기반 API, 키워드 + 서재 기반 API 두 개 모두 테스트해보며 더 추천에 적합한 API를 선택할 예정입니다.
 
  구현 내용
  1. 데이터 모델 추가
    - Member: 사용자 정보 (member_id만 저장)
    - Keyword: 키워드 정보 (MOOD, GENRE, CONTENT 타입)
    - Bookhouse: 사용자 서재 (member-book 관계)
    - member_keywords: 다대다 관계 테이블
  2. 추천 알고리즘 구현 (user_recommender.py)
    - 키워드만 기반: 사용자가 선택한 키워드들의 유사도 계산
    - 키워드 + 서재 책 기반: 키워드와 서재에 등록된 책 정보 모두 활용
    - TF-IDF 벡터화로 텍스트 특징 추출
    - 코사인 유사도로 사용자 간 유사성 측정
  3. API 엔드포인트
    - GET /recommend/users/keywords: 키워드만으로 추천
    - GET /recommend/users/combined: 키워드 + 서재 책으로 추천
    - 반환값: member_id 리스트, 유사도, 매칭된 키워드/책 정보

  특징
  - 추천 로직만 Python에서 처리하고 상세 정보는 Spring에서 관리
  - 매칭 이유(어떤 키워드/책이 일치했는지) 함께 제공

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
