### PR TITLE
fix: 서재책 없이도 책 추천, 책 response에 image 추가

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -50,7 +50,7 @@ def healthyCheck():
 
 @router.get("/recommend")
 def recommend(
-    book_ids: str = Query(..., description="추천 기준 책 ID, 콤마로 구분"),
+    book_ids: str = Query(None, description="추천 기준 책 ID, 콤마로 구분"),
     user_keywords: str = Query("", description="사용자 취향 키워드, 콤마로 구분 (예: 로맨스,감성,힐링)")
 ):
     """TF-IDF 기반 책 추천 (미리 계산된 매트릭스 사용)"""
@@ -62,10 +62,20 @@ def recommend(
 
     try:
         # 1. Query 파라미터 문자열 → 정수 리스트
-        ids = [int(x) for x in book_ids.split(",")]
+        ids = []
+        if book_ids:
+            ids = [int(x) for x in book_ids.split(",")]
+        
         keywords = [k.strip() for k in user_keywords.split(",") if k.strip()]
+        
+        # book_ids가 없고 keywords만 있는 경우 - 키워드 기반 추천
+        if not ids and keywords:
+            # 키워드만으로 추천
+            recommended_books_with_scores = tfidf_rec.recommend_by_keywords_only(
+                user_preference_keywords=keywords)
+            return build_recommendation_response(recommended_books_with_scores)
 
-        # 2. 미리 계산된 TF-IDF로 추천
+        # 2. 책 ID와 키워드 모두 사용한 추천
         recommended_books_with_scores = tfidf_rec.recommend_by_user_books(
             book_ids=ids,
             user_preference_keywords=keywords)

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -19,10 +19,10 @@ def fetch_books():
     keywords 컬럼은 NULL 가능.
     """
     candidates = [
-        "SELECT id AS book_id, book_name, keywords, author, publisher FROM books",
-        "SELECT book_id, book_name, keywords, author, publisher FROM books",
-        "SELECT id AS book_id, book_name, keyword AS keywords, author, publisher FROM books",
-        "SELECT book_id, book_name, keyword AS keywords, author, publisher FROM books",
+        "SELECT id AS book_id, book_name, keywords, author, publisher, book_image AS image FROM books",
+        "SELECT book_id, book_name, keywords, author, publisher, book_image AS image FROM books",
+        "SELECT id AS book_id, book_name, keyword AS keywords, author, publisher, book_image AS image FROM books",
+        "SELECT book_id, book_name, keyword AS keywords, author, publisher, book_image AS image FROM books",
     ]
 
     with engine.begin() as conn:
@@ -31,7 +31,7 @@ def fetch_books():
             try:
                 rows = conn.execute(text(sql)).mappings().all()
                 return [(int(r["book_id"]), r["book_name"], r["keywords"], 
-                        r.get("author", ""), r.get("publisher", "")) for r in rows]
+                        r.get("author", ""), r.get("publisher", ""), r.get("image", "")) for r in rows]
             except Exception as e:
                 last_err = e
                 continue

--- a/app/recommend/bert_recommender.py
+++ b/app/recommend/bert_recommender.py
@@ -14,6 +14,7 @@ class BertRecommender:
         self.book_keywords: Dict[int, str] = {}
         self.book_authors: Dict[int, str] = {}
         self.book_publishers: Dict[int, str] = {}
+        self.book_images: Dict[int, str] = {}
         self.book_reviews: Dict[int, str] = {}
         
         # 임베딩 저장
@@ -72,13 +73,21 @@ class BertRecommender:
     def build_keyword_embeddings(self, records: List[Tuple]):
         """키워드만 사용한 임베딩 구축"""
         with self._lock:
-            # 튜플 형식 확인 (3개 또는 5개 요소)
-            if records and len(records[0]) == 5:
+            # 튜플 형식 확인 (6개 요소 - image 추가)
+            if records and len(records[0]) == 6:
+                self.book_ids = [int(bid) for bid, _, _, _, _, _ in records]
+                self.book_names = {int(bid): name for bid, name, _, _, _, _ in records}
+                self.book_keywords = {int(bid): self.parse_keywords(kw) for bid, _, kw, _, _, _ in records}
+                self.book_authors = {int(bid): author for bid, _, _, author, _, _ in records}
+                self.book_publishers = {int(bid): publisher for bid, _, _, _, publisher, _ in records}
+                self.book_images = {int(bid): image for bid, _, _, _, _, image in records}
+            elif records and len(records[0]) == 5:
                 self.book_ids = [int(bid) for bid, _, _, _, _ in records]
                 self.book_names = {int(bid): name for bid, name, _, _, _ in records}
                 self.book_keywords = {int(bid): self.parse_keywords(kw) for bid, _, kw, _, _ in records}
                 self.book_authors = {int(bid): author for bid, _, _, author, _ in records}
                 self.book_publishers = {int(bid): publisher for bid, _, _, _, publisher in records}
+                self.book_images = {}
             else:
                 # 이전 형식 호환성 (3개 요소)
                 self.book_ids = [int(bid) for bid, _, _ in records]
@@ -86,6 +95,7 @@ class BertRecommender:
                 self.book_keywords = {int(bid): self.parse_keywords(kw) for bid, _, kw in records}
                 self.book_authors = {}
                 self.book_publishers = {}
+                self.book_images = {}
             
             if len(records) == 0:
                 self.keyword_embeddings = None
@@ -113,19 +123,28 @@ class BertRecommender:
                                  review_records: List[Tuple[int, str]]):
         """키워드 + 리뷰 결합 임베딩 구축"""
         with self._lock:
-            # 기본 정보 저장 - 튜플 형식 확인
-            if book_records and len(book_records[0]) == 5:
+            # 기본 정보 저장 - 튜플 형식 확인 (6개 요소 - image 추가)
+            if book_records and len(book_records[0]) == 6:
+                self.book_ids = [int(bid) for bid, _, _, _, _, _ in book_records]
+                self.book_names = {int(bid): name for bid, name, _, _, _, _ in book_records}
+                self.book_keywords = {int(bid): self.parse_keywords(kw) for bid, _, kw, _, _, _ in book_records}
+                self.book_authors = {int(bid): author for bid, _, _, author, _, _ in book_records}
+                self.book_publishers = {int(bid): publisher for bid, _, _, _, publisher, _ in book_records}
+                self.book_images = {int(bid): image for bid, _, _, _, _, image in book_records}
+            elif book_records and len(book_records[0]) == 5:
                 self.book_ids = [int(bid) for bid, _, _, _, _ in book_records]
                 self.book_names = {int(bid): name for bid, name, _, _, _ in book_records}
                 self.book_keywords = {int(bid): self.parse_keywords(kw) for bid, _, kw, _, _ in book_records}
                 self.book_authors = {int(bid): author for bid, _, _, author, _ in book_records}
                 self.book_publishers = {int(bid): publisher for bid, _, _, _, publisher in book_records}
+                self.book_images = {}
             else:
                 self.book_ids = [int(bid) for bid, _, _ in book_records]
                 self.book_names = {int(bid): name for bid, name, _ in book_records}
                 self.book_keywords = {int(bid): self.parse_keywords(kw) for bid, _, kw in book_records}
                 self.book_authors = {}
                 self.book_publishers = {}
+                self.book_images = {}
             
             # 리뷰 정보 저장 (review_records: [(book_id, review_json)])
             review_dict = {int(bid): self.parse_reviews(review) for bid, review in review_records}
@@ -194,6 +213,7 @@ class BertRecommender:
                     "book_name": self.book_names.get(bid, ""),
                     "author": self.book_authors.get(bid, ""),
                     "publisher": self.book_publishers.get(bid, ""),
+                    "image": self.book_images.get(bid, ""),
                     "keywords": self.book_keywords.get(bid, ""),
                     "similarity_score": round(score, 4),
                     "method": "keyword_only"
@@ -233,6 +253,7 @@ class BertRecommender:
                     "book_name": self.book_names.get(bid, ""),
                     "author": self.book_authors.get(bid, ""),
                     "publisher": self.book_publishers.get(bid, ""),
+                    "image": self.book_images.get(bid, ""),
                     "keywords": self.book_keywords.get(bid, ""),
                     "review_preview": review_preview,
                     "similarity_score": round(score, 4),
@@ -267,10 +288,11 @@ class BertRecommender:
                 bid = int(self.book_ids[i])
                 result = {
                     "book_id": bid,
-                    "book_name": self.book_names.get(bid, ""),
-                    "author": self.book_authors.get(bid, ""),
-                    "publisher": self.book_publishers.get(bid, ""),
-                    "keywords": self.book_keywords.get(bid, ""),
+                    "book_name": self.book_names.get(bid, "") or "",
+                    "author": self.book_authors.get(bid, "") or "",
+                    "publisher": self.book_publishers.get(bid, "") or "",
+                    "image": self.book_images.get(bid, "") or "",
+                    "keywords": self.book_keywords.get(bid, "") or "",
                     "similarity_score": round(score, 4),
                     "method": "text_search"
                 }
@@ -328,6 +350,7 @@ class BertRecommender:
                     "book_name": self.book_names.get(bid, ""),
                     "author": self.book_authors.get(bid, ""),
                     "publisher": self.book_publishers.get(bid, ""),
+                    "image": self.book_images.get(bid, ""),
                     "keywords": self.book_keywords.get(bid, ""),
                     "similarity_score": round(score, 4),
                     "method": "keyword_multi"
@@ -382,6 +405,7 @@ class BertRecommender:
                     "book_name": self.book_names.get(bid, ""),
                     "author": self.book_authors.get(bid, ""),
                     "publisher": self.book_publishers.get(bid, ""),
+                    "image": self.book_images.get(bid, ""),
                     "keywords": self.book_keywords.get(bid, ""),
                     "review_preview": review_preview,
                     "similarity_score": round(score, 4),

--- a/app/recommend/recommender_service.py
+++ b/app/recommend/recommender_service.py
@@ -1,11 +1,8 @@
-# DB 관련 import와 설정 제거 - 더 이상 필요 없음
-
 def build_recommendation_response(recommended_books_with_scores):
-    # 결과 리스트 생성 (이미 추천 결과에 image 포함됨)
     result = [
         {
             "bookId": b['book_id'],
-            "bookImage": b.get('image', ''),  # 이미 추천 결과에 포함된 image 사용
+            "bookImage": b.get('image', ''),
             "bookName": b['book_name'],
             "author": b.get('author', ''),
             "publisher": b.get('publisher', ''),

--- a/app/recommend/recommender_service.py
+++ b/app/recommend/recommender_service.py
@@ -1,35 +1,11 @@
-import os
-from sqlalchemy import create_engine, select
-from sqlalchemy.orm import sessionmaker
-from dotenv import load_dotenv
-from app.db.models import Book
-
-
-load_dotenv()
-DATABASE_URL = os.getenv("DATABASE_URL")
-if not DATABASE_URL:
-    raise RuntimeError("DATABASE_URL not set. Put it in .env")
-
-# engine과 session 정의
-engine = create_engine(DATABASE_URL, pool_pre_ping=True, future=True)
-SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+# DB 관련 import와 설정 제거 - 더 이상 필요 없음
 
 def build_recommendation_response(recommended_books_with_scores):
-    # 1. book_id 목록 추출
-    book_ids = [b['book_id'] for b, _, _ in recommended_books_with_scores]
-
-    # 2. DB에서 한 번에 조회
-    with SessionLocal() as session:
-        books_in_db = session.execute(
-            select(Book.book_id, Book.book_image).where(Book.book_id.in_(book_ids))
-        ).all()
-        book_images_map = {bid: img for bid, img in books_in_db}
-
-    # 3. 결과 리스트 생성
+    # 결과 리스트 생성 (이미 추천 결과에 image 포함됨)
     result = [
         {
             "bookId": b['book_id'],
-            "bookImage": book_images_map.get(b['book_id'], ""),
+            "bookImage": b.get('image', ''),  # 이미 추천 결과에 포함된 image 사용
             "bookName": b['book_name'],
             "author": b.get('author', ''),
             "publisher": b.get('publisher', ''),

--- a/app/recommend/tfidf_recommender.py
+++ b/app/recommend/tfidf_recommender.py
@@ -13,6 +13,7 @@ class TfidfRecommender:
         self.book_keywords: Dict[int, str] = {}
         self.book_authors: Dict[int, str] = {}
         self.book_publishers: Dict[int, str] = {}
+        self.book_images: Dict[int, str] = {}
         self.book_reviews: Dict[int, str] = {}
         self.corpus: List[str] = []
         
@@ -31,16 +32,19 @@ class TfidfRecommender:
                         reviews_by_book[book_id] = []
                     reviews_by_book[book_id].append(review_text)
         
-        # 책 데이터 처리 (튜플 형식: (book_id, book_name, keywords, author, publisher))
+        # 책 데이터 처리 (튜플 형식: (book_id, book_name, keywords, author, publisher, image))
         self.book_ids = []
         self.corpus = []
         
         for record in records:
-            if len(record) == 5:
+            if len(record) == 6:
+                book_id, book_name, keywords, author, publisher, image = record
+            elif len(record) == 5:
                 book_id, book_name, keywords, author, publisher = record
+                image = ''
             else:  # 이전 형식 호환성
                 book_id, book_name, keywords = record
-                author, publisher = '', ''
+                author, publisher, image = '', '', ''
             
             if not book_id:
                 continue
@@ -50,6 +54,7 @@ class TfidfRecommender:
             self.book_keywords[book_id] = keywords or ''
             self.book_authors[book_id] = author or ''
             self.book_publishers[book_id] = publisher or ''
+            self.book_images[book_id] = image or ''
             
             # 키워드와 리뷰 결합
             keyword_text = keywords or ''
@@ -150,7 +155,8 @@ class TfidfRecommender:
                 'book_name': self.book_names.get(book_id, ''),
                 'keyword': self.book_keywords.get(book_id, ''),
                 'author': self.book_authors.get(book_id, ''),
-                'publisher': self.book_publishers.get(book_id, '')
+                'publisher': self.book_publishers.get(book_id, ''),
+                'image': self.book_images.get(book_id, '')
             }
 
             # 추천하는 책과 관련있는 유저가 고른 키워드
@@ -159,6 +165,73 @@ class TfidfRecommender:
                 for kw in user_preference_keywords:
                     if self.book_keywords.get(book_id) and kw in self.book_keywords[book_id]:
                         related_keywords.append(kw)
+            related_keywords = related_keywords[:2]  # 최대 2개
+            book_info['related_user_keywords'] = related_keywords
+            
+            recommended_books_with_scores.append((book_info, score, review_keywords))
+        
+        return recommended_books_with_scores
+    
+    def recommend_by_keywords_only(
+        self,
+        user_preference_keywords: List[str],
+        top_n: int = 10
+    ) -> List[Tuple]:
+        """키워드만으로 책 추천 (책 ID 없이)"""
+        
+        if self.tfidf_matrix is None:
+            raise ValueError("TF-IDF matrix not initialized")
+        
+        if not user_preference_keywords:
+            raise ValueError("At least one keyword is required")
+        
+        # 키워드 텍스트로 벡터 생성
+        preference_text = " ".join(user_preference_keywords)
+        keyword_vec = self.vectorizer.transform([preference_text])
+        
+        # 모든 책과의 코사인 유사도 계산
+        sim_scores = cosine_similarity(keyword_vec, self.tfidf_matrix).flatten()
+        
+        # 상위 N개 선택
+        top_indices = sim_scores.argsort()[::-1][:top_n]
+        
+        # 결과 생성
+        keyword_top_n = 10
+        recommended_books_with_scores = []
+        
+        for idx in top_indices:
+            if sim_scores[idx] < 0.01:  # 최소 유사도 임계값
+                continue
+                
+            book_id = self.book_ids[idx]
+            score = sim_scores[idx]
+            
+            # 리뷰 키워드 추출
+            review_text = self.book_reviews.get(book_id, '')
+            if review_text:
+                review_keywords = extract_top_nouns(review_text)
+                if isinstance(review_keywords, str):
+                    review_keywords = review_keywords.split()[:keyword_top_n]
+                else:
+                    review_keywords = review_keywords[:keyword_top_n]
+            else:
+                review_keywords = []
+            
+            # 책 정보를 딕셔너리로 반환
+            book_info = {
+                'book_id': book_id,
+                'book_name': self.book_names.get(book_id, ''),
+                'keyword': self.book_keywords.get(book_id, ''),
+                'author': self.book_authors.get(book_id, ''),
+                'publisher': self.book_publishers.get(book_id, ''),
+                'image': self.book_images.get(book_id, '')
+            }
+
+            # 추천하는 책과 관련있는 유저가 고른 키워드
+            related_keywords = []
+            for kw in user_preference_keywords:
+                if self.book_keywords.get(book_id) and kw in self.book_keywords[book_id]:
+                    related_keywords.append(kw)
             related_keywords = related_keywords[:2]  # 최대 2개
             book_info['related_user_keywords'] = related_keywords
             


### PR DESCRIPTION
## ✨ Issue Number
> close #23 

## 📄 작업 내용 (주요 변경 사항)
DB 에서 image 도 가져오게 변경
recommend API 에서 서재 책 parameter를 생략가능하게 만들어, 신규회원이 책을 등록하지 않아도 온보딩 때 선택한 키워드만으로 책을 추천하게 하였습니다. 서재책+키워드로 tf-idf 하는 메소드와 키워드로 tf-idf 하는 메소드를 분리했습니다.

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
